### PR TITLE
Public profile view, improved participation dashboard

### DIFF
--- a/geeksurvey/forms.py
+++ b/geeksurvey/forms.py
@@ -13,11 +13,9 @@ class UserRegisterForm(UserCreationForm):
         fields = ['username', 'email', 'password1', 'password2']
 
 class UserUpdateForm(forms.ModelForm):
-    email = forms.EmailField()
-
     class Meta:
         model = User
-        fields = ['username', 'email']
+        fields = ['first_name', 'last_name']
 
 class ProfileUpdateForm(forms.ModelForm):
     class Meta:

--- a/geeksurvey/models.py
+++ b/geeksurvey/models.py
@@ -66,7 +66,7 @@ class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     # avatar = models.ImageField(default='/static/pfp_participant.png')
     bio = models.TextField(max_length=200)
-    age = models.PositiveSmallIntegerField(default=0)
+    age = models.PositiveSmallIntegerField(default=18)
     years_of_experience = models.PositiveSmallIntegerField(default=0)
     balance = models.DecimalField(default=0, max_digits=USD_MAX_DIGITS, decimal_places=USD_DECIMAL_NUM)
     country_of_origin = CountryField(default="US", blank_label='(Select Country)')

--- a/geeksurvey/templates/participate/index.html
+++ b/geeksurvey/templates/participate/index.html
@@ -4,11 +4,31 @@
 
 <h2> Participation Dashboard </h2>
 
-<!-- TODO make these real links -->
-<a href=""> Your Enrolled Studies </a>
-<br>
-<a href=""> Your Completed Studies </a>
-<br>
 <a href="{% url 'part_discover' %}"> Discover New Studies </a>
+<hr>
+<h3> Your Enrolled Studies </h3>
+
+{% for study in enrolled_studies %}
+
+  <p>
+  <a href="{% url 'study_landing_page' study.id %}">  
+    {{study.title}}
+  </a>
+  </p>
+
+{% endfor %}
+
+<hr>
+<h3> Your Completed Studies </h3>
+
+{% for study in completed_studies %}
+
+  <p>
+  <a href="{% url 'study_landing_page' study.id %}">  
+    {{study.title}}
+  </a>
+  </p>
+
+{% endfor %}
 
 {% endblock %}

--- a/geeksurvey/templates/profile/index.html
+++ b/geeksurvey/templates/profile/index.html
@@ -11,9 +11,9 @@
 <img class="user-avatar" src="{% static 'pfp_participant.png' %}" />
 <p> {{ profile.bio }}</p>
 <hr>
+<p> <a href="{% url 'profile_view' user.username %}"> view full profile </a> </p>
 <p> <a href="{% url 'profile_update' %}"> edit profile</a> </p>
 <p> <a href="{% url 'account_logout' %}"> log out </a> </p>
-
 
 {% endblock %}
 

--- a/geeksurvey/templates/profile/update.html
+++ b/geeksurvey/templates/profile/update.html
@@ -10,11 +10,7 @@
 <h2 class="account-heading">{{ user.username }}</h2>
 {% load socialaccount %}
 
-{% if user.socialaccount_set.all.0.get_avatar_url is defined %}
-  <img class="user-avatar" src="{{ user.socialaccount_set.all.0.get_avatar_url }}" />
-{% else %}
   <img class="user-avatar" src="{% static 'pfp_participant.png' %}" />
-{% endif %}
 
 <p class="text-secondary">{{ user.email }}</p>
 </div>
@@ -23,6 +19,7 @@
 {% csrf_token %}
 <fieldset class="form-group">
     <legend class="border-bottom mb-4">Profile Info</legend>
+    {{ u_form|crispy }} <!-- User form -->
     {{ p_form|crispy }} <!-- Profile form -->
 </fieldset>
 <div class="form-group">

--- a/geeksurvey/templates/profile/update.html
+++ b/geeksurvey/templates/profile/update.html
@@ -23,7 +23,6 @@
 {% csrf_token %}
 <fieldset class="form-group">
     <legend class="border-bottom mb-4">Profile Info</legend>
-    {{ u_form|crispy }} <!-- User form -->
     {{ p_form|crispy }} <!-- Profile form -->
 </fieldset>
 <div class="form-group">

--- a/geeksurvey/templates/profile/view.html
+++ b/geeksurvey/templates/profile/view.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block extra_head %}
+  <style>
+    table {
+      text-align:left;
+    }
+    td {
+      padding:1em;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+<h1>Profile</h1>
+<hr>
+<h2>{{ user.username }}</h2>
+<img class="user-avatar" src="{% static 'pfp_participant.png' %}" />
+<table>
+<tr>
+  <td> Full Name: </td>
+  <td> {{ user.first_name }} {{ user.last_name }} </td>
+</tr>
+<tr>
+  <td> Bio: </td>
+  <td> {{ profile.bio }} </td>
+</tr>
+<tr>
+  <td> Age: </td>
+  <td>{{ profile.age }}</td>
+</tr>
+<tr>
+  <td> Gender: </td>
+  <td>{{ profile.get_gender_display}} </td>
+</tr>
+<tr>
+  <td> Race / Ethnicity: </td>
+  <td>{{ profile.get_race_and_ethnicity_display }} </td>
+</tr>
+<tr>
+  <td> Occupation: </td>
+  <td> {{ profile.get_occupation_display }} </td>
+</tr>
+<tr>
+  <td> Years of Experience: </td>
+  <td>{{ profile.years_of_experience }}</td>
+</tr>
+<tr>
+  <td> Level Of Education: </td>
+  <td> {{ profile.get_level_of_education_display }} </td>
+</tr>
+<tr>
+  <td> Country of Origin: </td>
+  <td> {{ profile.get_country_of_origin_display }} </td>
+</tr>
+<tr>
+  <td> Current Location: </td>
+  <td>{{ profile.get_current_location_display }} </td>
+</tr>
+<tr>
+  <td> Experienced With Open Source? </td>
+  <td> {{ profile.get_open_source_experience_display }} </td>
+</tr>
+</table>
+
+{% endblock %}
+

--- a/geeksurvey/templates/research/index.html
+++ b/geeksurvey/templates/research/index.html
@@ -29,19 +29,22 @@
 {% block content %}
 
 <h2> Reseach Dashboard </h2>
+  <p> <a href="{% url 'study_create' %}"> create a study </a> </p>
+<hr>
 <h3> Your Studies </h3>
+<p> (click to edit) </p>
 
 {% for study in studies %}
 
-<a href="{% url 'study_edit' study.id %}" class='studyPreview'>  
-<div class='studyPreview'>
-  <h3> {{study.title}} </h3>
-  <p> {{study.description}} </p>
-  <p> {{study.owner}} </p>
+  <a href="{% url 'study_edit' study.id %}" class='studyPreview'>  
+  <div class='studyPreview'>
+    <h3> {{study.title}} </h3>
+    <p> {{study.description}} </p>
+    <p> {{study.owner}} </p>
 
-</div>
+  </div>
+  </a>
 
-</a>
 {% endfor %}
 
 {% endblock %}

--- a/geeksurvey/templates/study/landing.html
+++ b/geeksurvey/templates/study/landing.html
@@ -21,16 +21,16 @@
   {% endif %}
   <hr>
   <p> Description: {{study.description}} </p>
-  <p> Owner: {{study.owner}} </p>
+  <p> Owner: <a href="{% url 'profile_view' study.owner %}"> {{study.owner}} </a> </p>
   <p> Owner Bio: {{owner_profile.bio}} </p>
   <p> Enrolled:
-    {% for e in study.enrolled.all %}
-    <span> {{ e }} </span>
+    {% for enrolled_user in study.enrolled.all %}
+    <a href="{% url 'profile_view' enrolled_user %}"> {{ enrolled_user }} </a>,
     {% endfor %}
   </p>
   <p> Completed:
-    {% for e in study.completed.all %}
-    <span> {{ e }} </span>
+    {% for completed_user in study.completed.all %}
+    <a href="{% url 'profile_view' completed_user %}"> {{ completed_user }} </a>,
     {% endfor %}
   </p>
 

--- a/geeksurvey/urls.py
+++ b/geeksurvey/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path('study/enroll/<uuid:study_id>/fail/', views.study_enroll_fail, name='study_enroll_fail'),
     path('study/complete/<uuid:study_id>/', views.study_complete, name='study_complete'),
     path('profile/', views.profile, name='profile'),
+    path('profile/view/<str:username>', views.profile_view, name='profile_view'),
     path('profile/update/', views.profile_update, name='profile_update'),
     path('research/', views.research, name='research'),
     path('study/edit/<uuid:study_id>/', views.study_edit, name='study_edit'),

--- a/geeksurvey/views.py
+++ b/geeksurvey/views.py
@@ -52,12 +52,10 @@ def profile(request):
 def profile_update(request):
     profile = Profile.objects.get(user=request.user)
     if request.method == 'POST':
-        u_form = UserUpdateForm(request.POST, instance=request.user)
         p_form = ProfileUpdateForm(request.POST,
                                    request.FILES,
                                    instance=request.user.profile)
-        if u_form.is_valid() and p_form.is_valid():
-            u_form.save()
+        if p_form.is_valid():
             p_form.save()
             messages.success(request, f'Your account has been updated!')
             return redirect('profile') # Redirect back to profile page
@@ -68,7 +66,6 @@ def profile_update(request):
 
     context = {
         'profile': profile,
-        'u_form': u_form,
         'p_form': p_form
     }
 

--- a/geeksurvey/views.py
+++ b/geeksurvey/views.py
@@ -7,6 +7,8 @@ from django.contrib.auth import logout, authenticate, login
 from django.contrib.auth.decorators import login_required
 from datetime import datetime, timedelta
 
+import json
+
 from .models import Study
 from .models import Profile
 
@@ -21,12 +23,26 @@ def working(request):
 def help(request):
     return render(request, 'help.html')
 
+@login_required
 def participate(request):
-    return render(request, 'participate/index.html')
+    all_studies = Study.objects.all()
+    enrolled_studies = []
+    completed_studies = []
+    for study in all_studies:
+        if request.user in study.completed.all():
+            completed_studies.append(study)
+        elif request.user in study.enrolled.all():
+            enrolled_studies.append(study)
+
+    context = {
+        'enrolled_studies':enrolled_studies,
+        'completed_studies':completed_studies,
+      }
+
+    return render(request, 'participate/index.html', context)
 
 @login_required
 def part_discover(request):
-    # TODO filter by criteria
     user_profile = Profile.objects.get(user=request.user)
     all_studies = Study.objects.all()
     eligible_studies = []
@@ -35,11 +51,9 @@ def part_discover(request):
         if user_profile.can_enroll(study):
             eligible_studies.append(study)
 
-
-    # (use profile.can_enroll())
     context = {
         'studies': eligible_studies,
-    }
+      }
     return render(request, 'participate/discover.html', context)
 
 @login_required
@@ -48,14 +62,31 @@ def profile(request):
     context={'profile':profile}
     return render(request, 'profile/index.html', context)
 
+from django.core import serializers
+
+
+# public profile view, accesible by url
+def profile_view(request, username):
+    user = get_object_or_404(User, username=username)
+    profile = Profile.objects.get(user=user)
+
+    context = {
+        'user':user,
+        'profile':profile,
+      }
+
+    return render(request, 'profile/view.html', context)
+
 @login_required
 def profile_update(request):
     profile = Profile.objects.get(user=request.user)
     if request.method == 'POST':
+        u_form = UserUpdateForm(request.POST, instance=request.user)
         p_form = ProfileUpdateForm(request.POST,
                                    request.FILES,
                                    instance=request.user.profile)
-        if p_form.is_valid():
+        if u_form.is_valid() and p_form.is_valid():
+            u_form.save()
             p_form.save()
             messages.success(request, f'Your account has been updated!')
             return redirect('profile') # Redirect back to profile page
@@ -66,8 +97,9 @@ def profile_update(request):
 
     context = {
         'profile': profile,
+        'u_form': u_form,
         'p_form': p_form
-    }
+      }
 
     return render(request, 'profile/update.html', context)
 
@@ -77,8 +109,10 @@ def research(request):
 
     # show existing studies created by the user
     studies = Study.objects.filter(owner=request.user)
-    context = {'profile':profile,
-               'studies':studies}
+    context = {
+        'profile':profile,
+        'studies':studies
+      }
     return render(request, 'research/index.html', context)
 
 def study_update_helper(request, study, study_form):
@@ -117,7 +151,7 @@ def study_edit(request, study_id):
         if study_form.is_valid():
             study_update_helper(request, study, study_form)
             messages.success(request, f'Your study has been updated!')
-            return redirect('research')  # TODO redirect to research dashboard or study view page
+            return redirect('research')
     else:
         study_form = StudyUpdateForm(instance=study)
 
@@ -140,7 +174,7 @@ def study_create(request):
             study = Study()
             study_update_helper(request, study, study_form)
             messages.success(request, f'Your study has been created!')
-            return redirect('research')  # TODO redirect to research dashboard or study view page
+            return redirect('research')
     else:
         study_form = StudyUpdateForm(instance=Study())
 
@@ -161,7 +195,7 @@ def study_landing_page(request, study_id):
         'user':request.user,
         'study':study,
         'owner_profile':owner_profile,
-    }
+      }
     return render(request, 'study/landing.html', context)
 
 @login_required
@@ -180,7 +214,6 @@ def study_enroll(request, study_id):
        user.profile.years_of_experience > study.max_yoe:
     '''
     if not user_profile.can_enroll(study):
-        # TODO specify why you cant enroll.
         # if fail, go to failure page
         return redirect('study_enroll_fail', study_id)
 
@@ -189,12 +222,11 @@ def study_enroll(request, study_id):
     study.enrolled.add(request.user)
 
     # redirect to landing page
-    # TODO send to participation dashboard ?
     owner_profile = Profile.objects.get(user=study.owner)
     context = {
         'study':study,
         'owner_profile':owner_profile,
-    }
+      }
     return redirect('study_landing_page', study_id)
 
 @login_required
@@ -204,7 +236,7 @@ def study_enroll_fail(request, study_id):
     context = {
         'study':study,
         'profile':profile,
-    }
+      }
     return render(request, 'study/enroll_fail.html', context)
 
 @login_required
@@ -221,13 +253,14 @@ def study_complete(request, study_id):
 
         return redirect('study_landing_page', study_id)
     else:
-      study = get_object_or_404(Study, pk=study_id)
+        study = get_object_or_404(Study, pk=study_id)
 
-      # redirect if user not enrolled
-      if request.user not in study.enrolled.all():
-          return redirect('home')
+        # redirect if user not enrolled
+        if request.user not in study.enrolled.all():
+            return redirect('home')
 
-      study.completion_code = ""  # set to none so info doesnt render for user
-      complete_form = StudyCompleteForm(instance=study)
-      context = {'study':study, 'complete_form':complete_form}
-      return render(request, 'study/complete.html', context)
+        study.completion_code = ""  # set to none so info doesnt render for user
+        complete_form = StudyCompleteForm(instance=study)
+        context = {'study':study, 'complete_form':complete_form}
+        return render(request, 'study/complete.html', context)
+


### PR DESCRIPTION
I made a new view for public profiles. You can now view any at /profile/view/<username>/

This will be useful for researchers to see who is enrolled and for participants to learn about a study owner.

The owner's profile is linked from a study landing page, as well as the profiles for each enrolled / completed participant.

---

I also added some functionality in the participation dashboard at /participate/
It now contains links to all studies you have enrolled in or completed.

