### PR TITLE
Add study expiry calendar view and edit functionality

### DIFF
--- a/geeksurvey/models.py
+++ b/geeksurvey/models.py
@@ -21,7 +21,7 @@ class Payment(models.Model):
     amount = models.DecimalField(default=0, max_digits=USD_MAX_DIGITS,
                                     decimal_places=USD_DECIMAL_NUM)
     paid = models.BooleanField(default=False)
-    
+
 
 '''
 Define Custom Profile Fields
@@ -242,4 +242,3 @@ class Profile(models.Model):
 
     def __str__(self):
         return self.user.username
-

--- a/study/forms.py
+++ b/study/forms.py
@@ -1,10 +1,16 @@
 from django import forms
 from geeksurvey.models import Study
+from datetime import datetime
 
 class StudyUpdateForm(forms.ModelForm):
     class Meta:
+        class DateTimeInput(forms.DateTimeInput):
+            input_type = 'datetime-local'
+            input_value = 'expiry_date'
+
         model = Study
-        exclude = ['id', 'last_modified', 'enrolled', 'completed', 'owner', 'expiry_date', 'balance']
+        exclude = ['id', 'last_modified', 'enrolled', 'completed', 'owner', 'balance']
+        widgets = {'expiry_date' : DateTimeInput()}
 
 class StudyCompleteForm(forms.ModelForm):
     class Meta:
@@ -13,4 +19,3 @@ class StudyCompleteForm(forms.ModelForm):
 
 class StudyFundsForm(forms.Form):
     amount = forms.DecimalField()
-

--- a/study/views.py
+++ b/study/views.py
@@ -8,24 +8,26 @@ from django.shortcuts import render, get_object_or_404, redirect
 from geeksurvey.models import Study, Profile, User
 
 from datetime import datetime, timedelta
+from django.utils import timezone
 
 from .forms import *
 
 def study_update_helper(request, study, study_form):
-    title      = study_form.cleaned_data['title']
-    descr      = study_form.cleaned_data['description']
-    code       = study_form.cleaned_data['completion_code']
-    survey     = study_form.cleaned_data['survey_url']
-    comp       = study_form.cleaned_data['compensation']
-    min_age    = study_form.cleaned_data['min_age']
-    max_age    = study_form.cleaned_data['max_age']
-    min_yoe    = study_form.cleaned_data['min_yoe']
-    max_yoe    = study_form.cleaned_data['max_yoe']
-    req_edu    = study_form.cleaned_data['req_edu']
-    req_job    = study_form.cleaned_data['req_job']
-    req_rne    = study_form.cleaned_data['req_rne']
-    req_sex    = study_form.cleaned_data['req_sex']
-    req_oss    = study_form.cleaned_data['req_oss']
+    title       = study_form.cleaned_data['title']
+    descr       = study_form.cleaned_data['description']
+    code        = study_form.cleaned_data['completion_code']
+    survey      = study_form.cleaned_data['survey_url']
+    comp        = study_form.cleaned_data['compensation']
+    min_age     = study_form.cleaned_data['min_age']
+    max_age     = study_form.cleaned_data['max_age']
+    min_yoe     = study_form.cleaned_data['min_yoe']
+    max_yoe     = study_form.cleaned_data['max_yoe']
+    req_edu     = study_form.cleaned_data['req_edu']
+    req_job     = study_form.cleaned_data['req_job']
+    req_rne     = study_form.cleaned_data['req_rne']
+    req_sex     = study_form.cleaned_data['req_sex']
+    req_oss     = study_form.cleaned_data['req_oss']
+    expiry_date = study_form.cleaned_data['expiry_date']
     study.owner           = request.user
     study.title           = title
     study.description     = descr
@@ -41,22 +43,22 @@ def study_update_helper(request, study, study_form):
     study.req_rne         = req_rne
     study.req_sex         = req_sex
     study.req_oss         = req_oss
-    study.last_modified   = datetime.now()
-    study.expiry_date     = datetime.now()+timedelta(days=365)
+    study.last_modified   = timezone.make_aware(datetime.now())
+    study.expiry_date     = expiry_date
     study.save()
 
 def study_custom_labels(study_form):
     study_form['compensation'].label = "Compensation (USD)"
-    study_form['survey_url'].label = "Survey URL"
-    study_form['min_age'].label = "Minimum Age for Participants"
-    study_form['max_age'].label = "Maximum Age for Participants"
-    study_form['min_yoe'].label = "Minimum Years of Experience"
-    study_form['max_yoe'].label = "Maximum Years of Experience"
-    study_form['req_edu'].label = "Required Education"
-    study_form['req_job'].label = "Required Occupation"
-    study_form['req_rne'].label = "Required Race / Ethnicity"
-    study_form['req_sex'].label = "Required Gender"
-    study_form['req_oss'].label = "Require Experience With Open Source Development?"
+    study_form['survey_url'].label   = "Survey URL"
+    study_form['min_age'].label      = "Minimum Age for Participants"
+    study_form['max_age'].label      = "Maximum Age for Participants"
+    study_form['min_yoe'].label      = "Minimum Years of Experience"
+    study_form['max_yoe'].label      = "Maximum Years of Experience"
+    study_form['req_edu'].label      = "Required Education"
+    study_form['req_job'].label      = "Required Occupation"
+    study_form['req_rne'].label      = "Required Race / Ethnicity"
+    study_form['req_sex'].label      = "Required Gender"
+    study_form['req_oss'].label      = "Require Experience With Open Source Development?"
 
 @login_required
 def study_edit(request, study_id):


### PR DESCRIPTION
NOTE: Currently, the study expiry must be changed with every study update/creation. This is likely due to the default value of the datetime-local view in the generated HTML form field. The value is still being changed and saved in the database, but does not repopulate in the form with the current implementation. If we were to change back to the default DateTimeField view, this is not a problem and the form field would repopulate when updating the study.