### PR TITLE
Change expiry_date to date instead of datetime, fix unpopulated form field

### DIFF
--- a/geeksurvey/models.py
+++ b/geeksurvey/models.py
@@ -98,7 +98,7 @@ class Study(models.Model):
     title = models.CharField(max_length=100)
     description = models.TextField(max_length=400)
     last_modified = models.DateTimeField(auto_now_add=True)
-    expiry_date = models.DateTimeField('expiry date')
+    expiry_date = models.DateField('expiry date')
     balance = models.DecimalField(default=0, max_digits=USD_MAX_DIGITS,
                                     decimal_places=USD_DECIMAL_NUM)
     compensation = models.DecimalField(default=0, max_digits=USD_MAX_DIGITS,
@@ -209,7 +209,11 @@ class Profile(models.Model):
                               default=Gender.PREFER_NOT_TO_SAY)
 
     def can_enroll(self, study):
-        if datetime.now() > study.expiry_date.replace(tzinfo=None):
+        expiry_with_time = datetime(
+              year=study.expiry_date.year,
+              month=study.expiry_date.month,
+              day=study.expiry_date.day)
+        if datetime.now() > expiry_with_time:
             return False
 
         if self.age < study.min_age or \

--- a/study/forms.py
+++ b/study/forms.py
@@ -4,13 +4,17 @@ from datetime import datetime
 
 class StudyUpdateForm(forms.ModelForm):
     class Meta:
-        class DateTimeInput(forms.DateTimeInput):
-            input_type = 'datetime-local'
+        class DateInput(forms.DateInput):
+            input_type = 'date'
             input_value = 'expiry_date'
+
+            def __init__(self, **kwargs):
+                kwargs["format"] = "%Y-%m-%d"
+                super().__init__(**kwargs)
 
         model = Study
         exclude = ['id', 'last_modified', 'enrolled', 'completed', 'owner', 'balance']
-        widgets = {'expiry_date' : DateTimeInput()}
+        widgets = {'expiry_date' : DateInput()}
 
 class StudyCompleteForm(forms.ModelForm):
     class Meta:

--- a/study/views.py
+++ b/study/views.py
@@ -173,7 +173,7 @@ def study_create(request):
             send_mail_to_users(request, eligible_users, study)
 
             messages.success(request, f'Your study has been created!')
-            return redirect('research')
+        return redirect('research')
     else:
         study_form = StudyUpdateForm(instance=Study())
 


### PR DESCRIPTION
I changed the type of expiry_date to date instead of datetime, since we don't really need the time. This breaks existing studies (even after migrations). So better to do it now than later.

Also the form field for expiry date is correctly populated now.