### PR TITLE
Add email notification opt in/out functionality

### DIFF
--- a/geeksurvey/forms.py
+++ b/geeksurvey/forms.py
@@ -19,6 +19,4 @@ class UserUpdateForm(forms.ModelForm):
 class ProfileUpdateForm(forms.ModelForm):
     class Meta:
         model = Profile
-        fields = ['bio', 'age', 'years_of_experience', 'level_of_education', 'occupation', 'country_of_origin', 'current_location', 'race_and_ethnicity', 'open_source_experience', 'gender']
-
-
+        fields = ['bio', 'age', 'years_of_experience', 'level_of_education', 'occupation', 'country_of_origin', 'current_location', 'race_and_ethnicity', 'open_source_experience', 'gender', 'email_opt_in']

--- a/geeksurvey/models.py
+++ b/geeksurvey/models.py
@@ -90,6 +90,10 @@ class Gender(models.TextChoices):
     NONBINARY_GENDERQUEER_GENDER_NONCONFORMING = 'NGGN', _('Non-binary/Genderqueer/Gender Non-conforming')
     PREFER_NOT_TO_SAY                          = 'PNTS', _('Prefer Not to Say')
 
+class EmailOptIn(models.TextChoices):
+    YES = 'Y', _('Yes')
+    NO  = 'N', _('No')
+
 '''
   End of Profile Fields
 '''
@@ -209,6 +213,11 @@ class Profile(models.Model):
     gender = models.CharField(max_length=4,
                               choices=Gender.choices,
                               default=Gender.PREFER_NOT_TO_SAY)
+
+    # Adds email communication preference as a choosable field for the user profile.
+    email_opt_in = models.CharField(max_length=1,
+                                    choices=EmailOptIn.choices,
+                                    default=EmailOptIn.NO)
 
     def can_enroll(self, study):
         expiry_with_time = datetime(

--- a/geeksurvey/settings.py
+++ b/geeksurvey/settings.py
@@ -19,12 +19,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 DEBUG = bool( int( config("GEEKSURVEY_DEBUG") ) )
 print("DEBUG  : " + str(DEBUG))
 
-# email stuff
+# email config
 if DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
-else: 
+else:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_HOST_USER = config("GMAIL_APP_USERNAME")
 EMAIL_HOST_PASSWORD = config("GMAIL_APP_PASSWORD")

--- a/geeksurvey/views.py
+++ b/geeksurvey/views.py
@@ -96,6 +96,7 @@ def profile_update(request):
         p_form = ProfileUpdateForm(instance=request.user.profile)
 
         p_form['open_source_experience'].label = "Experienced With Open Source Development?"
+        p_form['email_opt_in'].label = "Opt In For Email Notifications?"
 
     context = {
         'profile': profile,
@@ -116,4 +117,3 @@ def research(request):
         'studies':studies
       }
     return render(request, 'research/index.html', context)
-

--- a/study/views.py
+++ b/study/views.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.contrib import messages
 from django.shortcuts import render, get_object_or_404, redirect
 from geeksurvey.models import Study, Profile, User
+from geeksurvey.settings import *
 
 from datetime import datetime, timedelta
 from django.utils import timezone
@@ -134,15 +135,16 @@ def send_mail_to_users(request, users, study):
     emails = []
     study_id = study.id
     for user in users:
-        emails.append(user.email)
-    print(emails)
+        profile = Profile.objects.get(user=user)
+        if(profile.email_opt_in == 'Y'):
+            emails.append(user.email)
     try:
         email_param = {
             'subject': 'New Study on GeekSurvey',
             'message': '',
             'html_message':
                 f"""
-                    <h2>You are eligable for a study at GeekSurvey!</h2>
+                    <h2>You are eligible for a study at GeekSurvey!</h2>
                     <p>Follow this link to the Survey:</p>
                     <a href="{request.build_absolute_uri(reverse('study_landing_page',
                                                                  args=(study_id,)))}">Click here to participate</a>


### PR DESCRIPTION
**NOTE:** The debug check for the email backend was temporarily disabled for testing. It is reenabled in this PR to avoid having our email bot flagged for spam during non-email functionality related testing.