### PR TITLE
Moved study helper functions to utils.py

### DIFF
--- a/geeksurvey/models.py
+++ b/geeksurvey/models.py
@@ -101,7 +101,7 @@ class EmailOptIn(models.TextChoices):
 class Study(models.Model):
     title = models.CharField(max_length=100)
     description = models.TextField(max_length=400)
-    last_modified = models.DateTimeField(auto_now_add=True)
+    last_modified = models.DateTimeField(auto_now=True)
     expiry_date = models.DateField('expiry date')
     balance = models.DecimalField(default=0, max_digits=USD_MAX_DIGITS,
                                     decimal_places=USD_DECIMAL_NUM)

--- a/study/forms.py
+++ b/study/forms.py
@@ -23,3 +23,4 @@ class StudyCompleteForm(forms.ModelForm):
 
 class StudyFundsForm(forms.Form):
     amount = forms.DecimalField()
+

--- a/study/utils.py
+++ b/study/utils.py
@@ -29,7 +29,6 @@ def study_send_mail(request, study):
            study.owner != user:
             emails.append(user.email)
 
-    print([study.title + " SENDING MAIL TO ", emails])
     if emails == []: return
 
     study_url = request.build_absolute_uri(reverse('study_landing_page', args=(study.id,)))

--- a/study/utils.py
+++ b/study/utils.py
@@ -1,0 +1,53 @@
+from django.core.mail import send_mail
+from django.urls import reverse
+
+from geeksurvey.models import Study, Profile, User
+from geeksurvey.settings import *
+
+
+def study_custom_labels(study_form):
+    study_form['compensation'].label = "Compensation (USD)"
+    study_form['survey_url'].label = "Survey URL"
+    study_form['min_age'].label = "Minimum Age for Participants"
+    study_form['max_age'].label = "Maximum Age for Participants"
+    study_form['min_yoe'].label = "Minimum Years of Experience"
+    study_form['max_yoe'].label = "Maximum Years of Experience"
+    study_form['max_nop'].label = "Maximum Number of Participants"
+    study_form['req_edu'].label = "Required Education"
+    study_form['req_job'].label = "Required Occupation"
+    study_form['req_rne'].label = "Required Race / Ethnicity"
+    study_form['req_sex'].label = "Required Gender"
+    study_form['req_oss'].label = "Require Experience With Open Source Development?"
+
+def study_send_mail(request, study):
+    all_users = User.objects.all()
+    emails = []
+    for user in all_users:
+        profile = Profile.objects.get(user=user)
+        if profile.can_enroll(study) and \
+           profile.email_opt_in == 'Y' and \
+           study.owner != user:
+            emails.append(user.email)
+
+    print([study.title + " SENDING MAIL TO ", emails])
+    if emails == []: return
+
+    study_url = request.build_absolute_uri(reverse('study_landing_page', args=(study.id,)))
+    try:
+        email_param = {
+            'subject': 'New Study on GeekSurvey',
+            'message': '',
+            'html_message':
+                f"""
+                    <h2>You are eligible for a study at GeekSurvey!</h2>
+                    <p>Follow this link to the Survey:</p>
+                    <a href="{study_url}">Click here to participate</a>
+
+                """,
+            'from_email': EMAIL_HOST_USER,
+            'recipient_list': emails,
+        }
+        res_mail = send_mail(**email_param)
+    except Exception as e:
+        print(e)
+


### PR DESCRIPTION
I decided to do a bit of cleanup.

1. helper functions don't belong in views.py, since each function is treated as a view by django.
     I moved the helpers from study/ into study/utils.py
2. study_update_helper was very unnecessary and only there because i was being lazy earlier in development. I removed it and replaced with a better way of doing things.

note that the above two changes do not change functionality, just implementation.
to maintain the same functionality, I changed study.last_modified to auto_now=True instead of auto_now_add=True

I also moved the eligibility logic for email notifications into the same conditional as the check for email_opt_in, and added a third condition which prevents notifications from being sent to the study owner.